### PR TITLE
Optimize rectification to avoid repeated DataFrame copies

### DIFF
--- a/src/EMGFlow/preprocess_signals.py
+++ b/src/EMGFlow/preprocess_signals.py
@@ -653,22 +653,23 @@ def bandpass_filter_signals(in_path:str, out_path:str, column_names=None, sampli
 # =============================================================================
 #
 
-def apply_rectify(Signal:pd.DataFrame, column_name:str):
+def apply_rectify(Signal:pd.DataFrame, column_name):
     """
-    Apply a Full Wave Rectifier (FWR) to a column of 'Signal'.
+    Apply a Full Wave Rectifier (FWR) to columns of 'Signal'.
 
     Parameters
     ----------
     Signal : pd.DataFrame
         A Pandas dataframe containing a 'Time' column, and additional columns
         for signal data.
-    column_name : str
-        The column of 'Signal' the FWR filter is applied to.
+    column_name : str or list-str
+        The column or list of columns of 'Signal' the FWR filter is applied to.
 
     Raises
     ------
     Exception
-        An exception is raised if 'column_name' is not a column of 'Signal'.
+        An exception is raised if a column from 'column_name' is not a column
+        of 'Signal'.
 
     Returns
     -------
@@ -677,12 +678,19 @@ def apply_rectify(Signal:pd.DataFrame, column_name:str):
 
     """
     
-    # An exception is raised if 'column_name' is not a column of 'Signal'.
-    if column_name not in list(Signal.columns.values):
-        raise Exception("Column '" + str(column_name) + "' not found in 'Signal'.")
+    if isinstance(column_name, str):
+        column_names = [column_name]
+    else:
+        column_names = column_name
+    
+    # An exception is raised if a column from 'column_name' is not a column of
+    # 'Signal'.
+    for column_name in column_names:
+        if column_name not in list(Signal.columns.values):
+            raise Exception("Column '" + str(column_name) + "' not found in 'Signal'.")
     
     fwr_Signal = Signal.copy().reset_index(drop=True)
-    fwr_Signal[column_name] = np.abs(fwr_Signal[column_name])
+    fwr_Signal[column_names] = np.abs(fwr_Signal[column_names])
     
     return fwr_Signal
 
@@ -772,9 +780,9 @@ def rectify_signals(in_path:str, out_path:str, column_names=None, expression:str
                 column_names = list(data.columns)
                 column_names = [column_name for column_name in column_names if column_name != 'Time' and not column_name.startswith('mask_')]
               
-            # Apply filter to columns
-            for column_name in column_names:
-                data = apply_rectify(data, column_name)
+            # Apply all columns at once to avoid copying the full dataframe
+            # once per column.
+            data = apply_rectify(data, column_names)
             
             # Construct out path
             out_file = out_path + file_dirs[file][len(in_path):]

--- a/tests/test_preprocess_signals.py
+++ b/tests/test_preprocess_signals.py
@@ -58,6 +58,16 @@ class TestSimple(unittest.TestCase):
         SSignal = EMGFlow.apply_rectify(Signal, 'EMG_zyg')
         self.assertIsInstance(SSignal, pd.DataFrame)
     
+    def test_apply_rectify_multiple_columns(self):
+        pathNames = EMGFlow.make_paths()
+        filePath = os.path.join(pathNames['raw'], '01', 'sample_data_01.csv')
+        Signal = EMGFlow.read_file_type(filePath, 'csv')
+        original = Signal.copy()
+        SSignal = EMGFlow.apply_rectify(Signal, ['EMG_zyg', 'EMG_cor'])
+        self.assertIsInstance(SSignal, pd.DataFrame)
+        self.assertTrue((SSignal[['EMG_zyg', 'EMG_cor']].dropna() >= 0).all().all())
+        pd.testing.assert_frame_equal(Signal, original)
+    
     def test_rectify_signals(self):
         pathNames = EMGFlow.make_paths()
         EMGFlow.rectify_signals(pathNames['raw'], pathNames['fwr'])


### PR DESCRIPTION
## Summary

  Optimizes rectify_signals() by applying rectification to all selected columns in one apply_rectify() call, instead of
  calling it once per column.

  Previously, each selected column triggered a full DataFrame copy. For multi-channel EMG files, this meant copying the
  same file level DataFrame repeatedly. The updated path copies the DataFrame once, then applies np.abs() across all
  selected columns together. This reduces unnecessary memory allocation and copy work while preserving the existing
  apply_rectify() API.

  ## Benchmark

This benchmark measures only the rectification path, specifically rectify_signals() / apply_rectify().

Used the EMG Physical Action Data Set:

https://www.kaggle.com/datasets/durgancegaur/emg-physical-action-data-set

  - 20 CSV files
  - 8 EMG channels
  - 192,862 total rows
  - 20 runs before and after

### Results:

Old: 0.6479s mean, 0.0066s std
New: 0.6145s mean, 0.0071s std

Runtime for this rectification benchmark improved by 5.16%.

Welch t-test:

t = 15.4087
p = 7.00e-18